### PR TITLE
[Day06] ▲ Next.js Route Handler에서 API 설계 - 강지현

### DIFF
--- a/problems/day06/강지현.ts
+++ b/problems/day06/강지현.ts
@@ -24,8 +24,8 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const category = Array.isArray(categoryInit) ? categoryInit[0] : categoryInit;
 
   if (category) {
-    if (!CATEGORIES.includes(category)) {
-      return res.status(400).json("존재하지 않는 카테고리입니다.");
+    if (!CATEGORIES.some((c) => c === category)) {
+      return res.status(400).json({ error: "존재하지 않는 카테고리입니다." });
     }
 
     const filter = products.filter((p) => p.category === category);
@@ -43,10 +43,13 @@ export function GET(req: Request) {
   const category = searchParams.get("category");
 
   if (category) {
-    if (!(CATEGORIES as readonly string[]).includes(category)) {
-      return NextResponse.json("존재하지 않는 카테고리입니다.", {
-        status: 400,
-      });
+    if (!CATEGORIES.some((c) => c === category)) {
+      return NextResponse.json(
+        { error: "존재하지 않는 카테고리입니다." },
+        {
+          status: 400,
+        },
+      );
     }
 
     const filter = products.filter((p) => p.category === category);


### PR DESCRIPTION
#23 

## 접근 방식
- 문제에서는 Page Router의 예제만 나와 있었지만 App Router의 코드도 작성하였습니다.
- 카테고리 타입을 `as const`와 `typeof`를 활용하여 별도로 정의하였습니다.

## 고민한 부분
- `category` 쿼리 파라미터가 배열로 올 수 있어서 `Array.isArray`로 단일 값으로 변환하여 처리하였습니다.
- 요구사항에 없었지만 잘못된 카테고리 입력에 대한 처리를 위해 유효성 검사를 추가하였습니다.
- App Router에서 `CATEGORIES` 타입이 `readonly string[]`이라 `includes` 사용 시 `as readonly string[]`로 타입 캐스팅하여 처리하였습니다.

## 소요 시간
-  30분 (Page Router와 App Router 모두 작성하려고 하다 보니 시간이 걸렸습니다)
