### PR TITLE
[Day12] ▲ Next.js 미들웨어로 인증 라우트 보호 - 강지현

### DIFF
--- a/problems/day12/강지현.ts
+++ b/problems/day12/강지현.ts
@@ -15,19 +15,22 @@ function authMiddleware(req: Request, res: Response, next: NextFunction) {
 }
 
 // 예시 요청 객체
-const req = {};
+const req = {} as Request;
 
 // 예시 응답 객체
 const res = {
   redirect: (url: string) => {
     console.log(`Redirecting to ${url}`);
   },
-};
+} as Response;
 
 // 예시 next 함수
 function next() {
   console.log("Access granted to protected route");
 }
 
-// 미들웨어 테스트
+// 미들웨어 테스트 (인증되지 않은 경우)
+authMiddleware(req, res, next);
+// 미들웨어 테스트 (인증된 경우)
+user.isAuthenticated = true;
 authMiddleware(req, res, next);


### PR DESCRIPTION
#46

## 접근 방식
- `user.isAuthenticated` 값을 확인하여 인증된 경우 `next()`를 호출하고, 
  인증되지 않은 경우 `res.redirect('/login')`으로 로그인 페이지로 리다이렉트하도록 구현하였습니다.

## 고민한 부분
- `req`, `res`, `next` 파라미터의 타입을 어떻게 설정할지 고민하였고, 
  Express에서 제공하는 `Request`, `Response`, `NextFunction` 타입을 import하여 사용하였습니다.

## 소요 시간
- 15분

## 흐름
- `isAuthenticated: false` → `res.redirect('/login')` → 로그인 페이지로 이동
- `isAuthenticated: true` → `next()` → 보호된 라우트 접근