### PR TITLE
[Day13] 🔷 쇼핑몰 주문 상태에 따른 타입 변환 - 강지현

### DIFF
--- a/problems/day13/강지현.ts
+++ b/problems/day13/강지현.ts
@@ -15,7 +15,7 @@ const orders: Order[] = [
 ];
 
 type OrderDetails<T extends OrderStatus> = {
-  pending: Pick<Order, "id" | "product" | "price" | "quantity">;
+  pending: Omit<Order, "status">;
   shipped: Pick<Order, "id" | "product"> & { trackingNumber: string };
   delivered: Pick<Order, "id" | "product"> & { deliveredAt: string };
 }[T];
@@ -28,13 +28,10 @@ function getOrderDetails<T extends OrderStatus>(
     .filter((order) => order.status === status)
     .map((order) => {
       // status에 따라 다른 속성 반환
-      if (status === "pending")
-        return {
-          id: order.id,
-          product: order.product,
-          price: order.price,
-          quantity: order.quantity,
-        } as OrderDetails<T>;
+      if (status === "pending") {
+        const { status: _, ...rest } = order;
+        return rest as OrderDetails<T>;
+      }
       if (status === "shipped")
         return {
           id: order.id,
@@ -44,7 +41,16 @@ function getOrderDetails<T extends OrderStatus>(
       return {
         id: order.id,
         product: order.product,
-        deliveredAt: "SEOUL",
+        deliveredAt: new Date().toISOString(),
       } as OrderDetails<T>;
     });
 }
+
+// pending 주문 조회
+console.log(getOrderDetails(orders, "pending"));
+
+// shipped 주문 조회
+console.log(getOrderDetails(orders, "shipped"));
+
+// delivered 주문 조회
+console.log(getOrderDetails(orders, "delivered"));


### PR DESCRIPTION
#49 

## 접근 방식
- 상태별로 다른 타입을 반환하기 위해 Mapped Type을 사용하였습니다.
- `Order` 타입을 활용하기 위해 `Pick`을 사용하였습니다.
- `filter`로 상태가 일치하는 주문만 걸러내고 map으로 변환했습니다.

## 고민한 부분
- 각 상태별 속성을 직접 정의할지 `Pick`을 쓸지 고민했지만, 중복 선언을 막기 위해 `Pick`을 사용하였습니다.
- `map`이 `undefined`를 반환할 수 있어서 타입 에러가 발생했고, 마지막 `if`를 `return`으로 바꿔서 해결했습니다.

## 소요 시간
- 15분

## 실행

### 테스트 코드
```ts
// pending 주문 조회
console.log(getOrderDetails(orders, 'pending'));

// shipped 주문 조회
console.log(getOrderDetails(orders, 'shipped'));

// delivered 주문 조회
console.log(getOrderDetails(orders, 'delivered'));
```

### 실행 결과
<img width="440" height="440" alt="image" src="https://github.com/user-attachments/assets/ab937859-a57f-4d6f-8cf6-011aff603723" />