### PR TITLE
[Day14] 🧩 트리 구조 탐색을 통한 댓글 수 세기 - 강지현

### DIFF
--- a/problems/day14/강지현.js
+++ b/problems/day14/강지현.js
@@ -34,9 +34,7 @@ function countCommentsByAuthor(comments, author) {
     }
 
     // 하위 자식이 있을 경우, 자식의 댓글 확인
-    if (comment.children.length > 0) {
-      count += countCommentsByAuthor(comment.children, author);
-    }
+    count += countCommentsByAuthor(comment.children, author);
   }
 
   return count;


### PR DESCRIPTION
#53 

## 접근 방식
- 재귀로 트리 구조를 탐색하면서 `author`가 일치하면 `count`를 증가시켰습니다.
- 확인하는 댓글에 `children`이 있으면 재귀 호출로 하위 댓글까지 탐색하도록 구현하였습니다.

## 고민한 부분
- DFS 방식으로 visited, stack을 써야 하나 고민했지만, 트리 구조라 재귀만으로 충분해서 재귀방식으로 구현하였습니다.

## 소요 시간
- 10분

## 실행

### 테스트 코드
```js
console.log(countCommentsByAuthor(comments, "Alice"));
```

### 실행 결과
<img width="433" height="47" alt="image" src="https://github.com/user-attachments/assets/4b76d5bc-93aa-4647-b53e-e2135ff7a96a" />