### PR TITLE
[Day16] ▲ Next.js에서 generateMetadata로 동적 SEO 구현하기 - 강지현

### DIFF
--- a/problems/day16/강지현.ts
+++ b/problems/day16/강지현.ts
@@ -7,14 +7,7 @@ interface Product {
   price: number;
 }
 
-const product: Product = {
-  id: 101,
-  name: "Wireless Headphones",
-  description: "High quality wireless headphones with noise cancellation",
-  price: 299.99,
-};
-
-function generateProductMetadata(product: Product): Metadata {
+export function generateProductMetadata(product: Product): Metadata {
   return {
     title: product.name,
     description: product.description,


### PR DESCRIPTION
#59 

## 접근 방식
- `product.name`을 `title`로, `product.description`을 `description`으로 설정한 객체를 반환하도록 했습니다.
- Next.js의 `Metadata` 타입을 `import`해서 반환 타입으로 사용했습니다.

## 고민한 부분
- `product` 파라미터 타입을 직접 정의할지 고민했고, `interface Product`로 정의해서 사용했습니다.

## 소요 시간
- 5분